### PR TITLE
Patch to allow SQL in non-SQL files to be run

### DIFF
--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -82,15 +82,8 @@ export default class MainController implements vscode.Disposable {
     // get the T-SQL query from the editor, run it and show output
     public onRunQuery()
     {
-        if(!Utils.isEditingSqlFile())
-        {
-            Utils.showWarnMsg(Constants.gMsgOpenSqlFile);
-        }
-        else
-        {
-            const self = this;
-            let qr = new QueryRunner(self._connectionMgr, self._statusview, self._outputContentProvider);
-            qr.onRunQuery();
-        }
+        const self = this;
+        let qr = new QueryRunner(self._connectionMgr, self._statusview, self._outputContentProvider);
+        qr.onRunQuery();
     }
 }

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -51,7 +51,6 @@ export const gMsgContentProviderProvideContent = 'Content provider: provideTextD
 
 export const gExtensionActivated = "activated.";
 export const gExtensionDeactivated = "de-activated.";
-export const gMsgOpenSqlFile = "To use this command, Open a .sql file -or- Change editor language to 'SQL' -or- Select some T-SQL text in the active SQL editor.";
 
 export const gRecentConnectionsPlaceholder = "Choose a connection from the list below";
 export const gMsgNoConnectionsInSettings = "To use this command, add connection information to VS Code User or Workspace settings.";

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -2,21 +2,6 @@
 import vscode = require('vscode');
 import Constants = require('./constants');
 
-// Return 'true' if the active editor window has a .sql file, false otherwise
-export function isEditingSqlFile()
-{
-    let sqlFile = false;
-    let editor = getActiveTextEditor();
-    if(editor)
-    {
-        if (editor.document.languageId == Constants.gLanguageId)
-        {
-            sqlFile = true;
-        }
-    }
-    return sqlFile;
-}
-
 // Return the active text editor if there's one
 export function getActiveTextEditor()
 {


### PR DESCRIPTION
This patch removes the isEditingSqlFile check that prevents a user from running a selected SQL statement unless that statement is in a SQL file (or at least a file where the language mode is set to "SQL").  This patch is desirable because SQL can be embedded in other file types, e.g. XML, and it should be possible to select that SQL and run it.

The central change is removing the "if(!Utils.isEditingSqlFile())" logic in the src/controllers/controller.ts file.  The other changes are for just removing code that this patch renders superfluous.
